### PR TITLE
Faster items addition for the dates-based list.

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -355,6 +355,7 @@ try:
 
     def listDates():
         day_names = []
+        listing = []
         for i in range(7):
             day_names.append(_lang_(31000 + i))
         dt = datetime.now();
@@ -362,8 +363,10 @@ try:
         while dt > min_date:
             pretty_date = day_names[dt.weekday()] + " " + dt.strftime("%d.%m.%Y")
             formated_date = dt.strftime("%Y-%m-%d")
-            addDirectoryItem(pretty_date, _baseurl_ + "?date=" + urllib.quote_plus(formated_date))
+            list_item = xbmcgui.ListItem(label=pretty_date)
+            listing.append((_baseurl_ + "?date=" + urllib.quote_plus(formated_date), list_item, True))
             dt = dt - timedelta(days=1)
+        xbmcplugin.addDirectoryItems(_handle_, listing, len(listing))
         xbmcplugin.endOfDirectory(_handle_, updateListing=False, cacheToDisc=False)
 
 


### PR DESCRIPTION
This commit speeds up the addition of items to the "Date" listing.
While on high-end devices this has no noticable effect, in Kodi
18.1/LibreELEC 9.0 and the ARM rock64 SBC, addition of the 5k+ date
items can sometimes take around a minute, which is unacceptable.
This patch makes entering those 5k+ dates acceptable again (2-3s).

See: https://kodi.wiki/view/HOW-TO:Video_addon for more detail.