### PR TITLE
Add support for temporary channels

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -252,8 +252,8 @@ try:
     def listLiveChannels():
         xbmcplugin.setContent(_handle_, "episodes")
         for liveChannel in ivysilani.LIVE_CHANNELS:
-            title = _toString(liveChannel.title)
             live_programme = liveChannel.programme()
+            title = _toString(liveChannel.title)
             if hasattr(live_programme, "title") and live_programme.title:
                 title += ": " + _toString(live_programme.title)
             plot = None
@@ -270,12 +270,13 @@ try:
                     continue
                 except:
                     pass
-            title += " [" + _toString(_lang_(30002)) + "]"
-            url = _baseurl_ + "?menu=live"
-            image = None
-            if hasattr(live_programme, 'imageURL') and live_programme.imageURL:
-                image = live_programme.imageURL
-            addDirectoryItem(title, url, image=image)
+            if liveChannel.permanent:
+                title += " [" + _toString(_lang_(30002)) + "]"
+                url = _baseurl_ + "?menu=live"
+                image = None
+                if hasattr(live_programme, 'imageURL') and live_programme.imageURL:
+                    image = live_programme.imageURL
+                addDirectoryItem(title, url, image=image)
         xbmcplugin.endOfDirectory(_handle_, updateListing=False, cacheToDisc=False)
 
 
@@ -372,10 +373,11 @@ try:
 
     def listChannelsForDate(date):
         for channel in ivysilani.LIVE_CHANNELS:
-            image = xbmc.translatePath(os.path.join(_addon_.getAddonInfo('path'), 'resources', 'media',
-                                                    'logo_' + channel.ID.lower() + '_400x225.png'))
-            url = _baseurl_ + "?date=" + urllib.quote_plus(date) + "&channel=" + channel.ID
-            addDirectoryItem(_toString(channel.title), url, image=image)
+            if channel.permanent:
+                image = xbmc.translatePath(os.path.join(_addon_.getAddonInfo('path'), 'resources', 'media',
+                                                        'logo_' + channel.ID.lower() + '_400x225.png'))
+                url = _baseurl_ + "?date=" + urllib.quote_plus(date) + "&channel=" + channel.ID
+                addDirectoryItem(_toString(channel.title), url, image=image)
         xbmcplugin.endOfDirectory(_handle_, updateListing=False, cacheToDisc=False)
 
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.ivysilani" name="iVysílání — Česká televize" version="1.3.6" provider-name="Štěpán Ort">
+<addon id="plugin.video.ivysilani" name="iVysílání — Česká televize" version="1.3.7" provider-name="Štěpán Ort">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.stream.resolver" version="1.6.13"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2019-05-16 [1.3.7]
+ * Show temporary channels (Olympics, ...) if broadcasting
 2018-05-10 [1.3.6]
  * Fix playback url change. Thx petrprochy
 2018-01-28 [1.3.5]

--- a/ivysilani.py
+++ b/ivysilani.py
@@ -229,10 +229,11 @@ class _Playable:
 class LiveChannel(_Playable):
     _programme = None
 
-    def __init__(self, channel, ID, title):
+    def __init__(self, channel, title='', permanent=False):
         self.channel = channel
-        self.ID = ID
+        self.ID = 'CT' + self.channel
         self.title = title
+        self.permanent = permanent
 
     def programme(self):
         if self._programme is None:
@@ -240,13 +241,6 @@ class LiveChannel(_Playable):
         return self._programme
 
     def _refresh(self):
-        if self.channel is None:
-            self._programme = Programme()
-            setattr(self._programme, "title", None)
-            setattr(self._programme, "ID", self.ID)
-            setattr(self._programme, "imageURL",
-                    "http://imgct.ceskatelevize.cz/cache/w400/upload/program/porady/11529101711/foto/uni.jpg")
-            return None
         params = {"imageType": IMAGE_WIDTH,
                   "current": 1,
                   "channel": self.channel}
@@ -260,6 +254,8 @@ class LiveChannel(_Playable):
         programme = root[0][0][0]
         for child in programme:
             setattr(self._programme, child.tag, child.text)
+        if hasattr(self._programme, "channelTitle") and self._programme.channelTitle:
+            self.title = self._programme.channelTitle
 
 
 # Program
@@ -419,21 +415,23 @@ QUALITIES = ["mobile", "288p", "404p", "web", "720p", "1080p"]
 PAGE_SIZE = 25
 
 # Živě
-LIVE_CHANNELS = [LiveChannel("1", "CT1", "ČT1"),
-                 LiveChannel("2", "CT2", "ČT2"),
-                 LiveChannel("24", "CT24", "ČT24"),
-                 LiveChannel("4", "CT4", "ČT Sport"),
-                 LiveChannel("5", "CT5", "ČT :D"),
-                 LiveChannel("6", "CT6", "ČT art"),
-                 # LiveChannel(None, "CT26", "ČT LOH1"),
-                 # LiveChannel(None, "CT27", "ČT LOH2"),
-                 # LiveChannel(None, "CT28", "ČT LOH3"),
-                 # LiveChannel(None, "CT29", "ČT LOH4"),
-                 # LiveChannel(None, "CT30", "ČT LOH5"),
-                 # LiveChannel(None, "CT31", "ČT LOH6"),
-                 # LiveChannel(None, "CT32", "ČT LOH7"),
-                 # LiveChannel(None, "CT33", "ČT LOH8"),
-                 # LiveChannel(None, "CTmobile03", "ČT LOH Lipno"),
+LIVE_CHANNELS = [LiveChannel("1", "ČT1", True),
+                 LiveChannel("2", "ČT2", True),
+                 LiveChannel("24", "ČT24", True),
+                 LiveChannel("4", "ČT Sport", True),
+                 LiveChannel("5", "ČT :D", True),
+                 LiveChannel("6", "ČT art", True),
+                 LiveChannel("9"),
+                 LiveChannel("25"),
+                 LiveChannel("26"),
+                 LiveChannel("27"),
+                 LiveChannel("28"),
+                 LiveChannel("29"),
+                 LiveChannel("mobile"),
+                 LiveChannel("mobile2"),
+                 LiveChannel("mobile03"),
+                 LiveChannel("mobile04"),
+                 LiveChannel("mobile05"),
                  ]
 # 1, 2, 24, 4, 5, 6, 9, 25, 26, 27, 28, 29, mobile, mobile2, mobile03, mobile04, mobile05
 # Výběry


### PR DESCRIPTION
This commit adds the support for temporary live channels if there is
something being broadcasted there. These channels are typically used
during sport events like Olympics or Ice Hockey World Championships.

Resolves #32