### PR TITLE
Let Kodi handle video playing

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -35,7 +35,7 @@ if REMOTE_DBG:
 ###############################################################################
 
 params = None
-_addon_ = xbmcaddon.Addon('plugin.video.ivysilani.cz')
+_addon_ = xbmcaddon.Addon('plugin.video.ivysilani')
 _lang_ = _addon_.getLocalizedString
 _scriptname_ = _addon_.getAddonInfo('name')
 _version_ = _addon_.getAddonInfo('version')
@@ -168,6 +168,8 @@ try:
                          duration=None,
                          icon=_icon_, image=None, fanart=None, isFolder=True):
         li = xbmcgui.ListItem(label)
+        if (isFolder == False):
+            li.setProperty('IsPlayable','true');
         if not title:
             title = label
         liVideo = {'title': title}
@@ -288,12 +290,10 @@ try:
             url = res.geturl()
         finally:
             res.close()
-        player = xbmc.Player()
-        player.play(url, li)
+        li.setPath(url)
         if subtitles:
-            while not player.isPlaying():
-                xbmc.sleep(2000)
-            player.setSubtitles(_subtitles_path_)
+            li.setSubtitles([_subtitles_path_])
+        xbmcplugin.setResolvedUrl(_handle_, True, li)
 
 
     def playPlayable(playable, skipAutoQuality=False, forceQuality=None):
@@ -399,7 +399,7 @@ try:
             if hasattr(item, "synopsis") and item.synopsis:
                 plot = item.synopsis
             addDirectoryItem(item.title, _baseurl_ + "?play=" + item.ID, ID=item.ID, related=True, plot=plot,
-                             image=item.imageURL)
+                             image=item.imageURL, isFolder=False)
         if len(l) == ivysilani.PAGE_SIZE:
             addDirectoryItem('[B]' + _lang_(30006) + ' >>[/B]',
                              _baseurl_ + "?" + what + "=" + ID + "&page=" + str(page + 1), image=_next_)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.ivysilani.cz" name="iVysílání — Česká televize" version="1.3.8" provider-name="Štěpán Ort">
+<addon id="plugin.video.ivysilani" name="iVysílání — Česká televize" version="1.3.8" provider-name="Štěpán Ort">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.stream.resolver" version="1.6.13"/>


### PR DESCRIPTION
Removed manual player creation.
Videos are playable items now, instead of folders. Kodi can now remember last play position, so that user can resume playing video later, without having to seek manually.